### PR TITLE
Silence output from FFMpeg

### DIFF
--- a/lib/av/commands/ffmpeg.rb
+++ b/lib/av/commands/ffmpeg.rb
@@ -8,7 +8,7 @@ module Av
       def initialize(options = {})
         super(options)
         @command_name = "ffmpeg"
-        # TODO handle quite for ffmpeg
+        @default_params['loglevel'] = 'quiet' unless options[:quiet] == false
       end
       
       def filter_concat list


### PR DESCRIPTION
Silence the output from FFMpeg - it seems it accepts the same command line as avconv
