### PR TITLE
Fix for filter_rotate commands resulting in error

### DIFF
--- a/lib/av/commands/avconv.rb
+++ b/lib/av/commands/avconv.rb
@@ -24,11 +24,11 @@ module Av
         raise ::Av::InvalidFilterParameter unless degrees % 90 == 0
         case degrees
           when 90
-            add_input_param vf: 'clock'
+            add_output_param vf: 'clock'
           when 180
-            add_input_param vf: 'vflip,hflip'
+            add_output_param vf: 'vflip,hflip'
           when 270
-            add_input_param vf: 'cclock'
+            add_output_param vf: 'cclock'
         end
       end
       

--- a/lib/av/commands/ffmpeg.rb
+++ b/lib/av/commands/ffmpeg.rb
@@ -31,11 +31,11 @@ module Av
         raise ::Av::InvalidFilterParameter unless degrees % 90 == 0
         case degrees
           when 90
-            add_input_param vf: 'transpose=1'
+            add_output_param vf: 'transpose=1'
           when 180
-            add_input_param vf: 'vflip,hflip'
+            add_output_param vf: 'vflip,hflip'
           when 270
-            add_input_param vf: 'transpose=2'
+            add_output_param vf: 'transpose=2'
         end
         self
       end


### PR DESCRIPTION
The filter_rotate command was resulting ffmpeg failing because of the ordering of arguments - looks like this should be an output parameter instead.

I've also changed avconv, but that is untested - I'm not sure if avconv is less particular about the ordering or if this was failing as well.
