### PR TITLE
ParamHash should be combining parameters with a comma

### DIFF
--- a/lib/av/param_hash.rb
+++ b/lib/av/param_hash.rb
@@ -3,7 +3,7 @@ module Av
     def to_s
       line = []
       self.each do |option, value|
-        value = value.join(' ') unless value.is_a?(String)
+        value = value.join(',') if value.is_a?(Array)
         line << "-#{option} #{value}"
       end
       line.join(' ')

--- a/spec/av/base_spec.rb
+++ b/spec/av/base_spec.rb
@@ -31,7 +31,7 @@ describe Av::Commands::Base do
         subject.add_input_param(:k, 'value2')
         subject.add_input_param([:x, 'y'])
       end
-      it { expect(subject.input_params.to_s).to eq '-k value value1 value2 -x y' }
+      it { expect(subject.input_params.to_s).to eq '-k value,value1,value2 -x y' }
     end
   end
 
@@ -46,7 +46,7 @@ describe Av::Commands::Base do
         subject.add_output_param(:k, 'value2')
         subject.add_output_param([:x, 'y'])
       end
-      it { expect(subject.output_params.to_s).to eq '-k value value1 value2 -x y' }
+      it { expect(subject.output_params.to_s).to eq '-k value,value1,value2 -x y' }
     end
   end
 


### PR DESCRIPTION
I'm not entirely convinced this is correct so it could do with some review _but_ param hash currently combines multiple parameters of the same type using a space so for example

add_output_parameter :vcodec, 'libvpx'
add_output_parameter :acodec, 'libvorbis'
add_output_parameter :vf, 'vflip'
add_output_parameter :vf, 'hflip'

Would result in

-vcodec libvpx -acodec libvorbis -vf vflip hflip

Surely this should instead be

-vcodec libvpx -acodec libvorbis -vf vflip,hflip

Is there any situation where use of the same parameter multiple times should result in the parameters being separated by spaces? If not then I think this should be probably merged?
