### PR TITLE
Ivalid UTF-8 output from shell raise an exception ArgumentError: invalid byte sequence in UTF-8

### DIFF
--- a/lib/av/commands/base.rb
+++ b/lib/av/commands/base.rb
@@ -95,7 +95,7 @@ module Av
         meta = {}
         command = %Q(#{@command_name} -i "#{File.expand_path(path)}" 2>&1)
         out = ::Av.run(command, [0,1]).encode('UTF-8', 'UTF-8', invalid: :replace)
-        out.split("\n").each do |line|
+        out.encode('UTF-8', :invalid => :replace).split("\n").each do |line|
           if line =~ /(([\d\.]*)\s.?)fps,/
             meta[:fps] = $1.to_i
           end


### PR DESCRIPTION
fix bug if out with invalid utf

``` ruby
out = "avconv version 9.18-6:9.18-0ubuntu0.14.04.1, Copyright (c) 2000-2014 the Libav developers\n  built on Mar 16 2015 13:19:10 with gcc 4.8 (Ubuntu 4.8.2-19ubuntu1)\nGuessed Channel Layout for  Input Stream #0.0 : stereo\nInput #0, wav, from '/tmp/2c2c480c3218b971a9d7b936a98db93c20150812-1993-1r84jvw.wav':\n  Metadata:\n    date            : 2014-08-28\n    IENG            : \xCF\xEE\xEB\xFC\xE7\xEE\xE2\xE0\xF2\xE5\xEB\xFC Windows\n    encoder         : Sound Forge Pro 10.0\n  Duration: 00:00:01.48, bitrate: 1537 kb/s\n    Stream #0.0: Audio: pcm_s16le, 48000 Hz, stereo, s16, 1536 kb/s\nAt least one output file must be specified\n"
out.split("\n")
```
