### PR TITLE
Fixed handling of UTF8 metadata output from FFMpeg

### DIFF
--- a/lib/av/commands/base.rb
+++ b/lib/av/commands/base.rb
@@ -94,7 +94,8 @@ module Av
       def identify path
         meta = {}
         command = %Q(#{@command_name} -i "#{File.expand_path(path)}" 2>&1)
-        out = ::Av.run(command, [0,1]).encode('UTF-8', 'UTF-8', invalid: :replace)
+        out = ::Av.run(command, [0,1])
+        out = out.force_encoding('UTF-8').encode('UTF-8', invalid: :replace)
         out.split("\n").each do |line|
           if line =~ /(([\d\.]*)\s.?)fps,/
             meta[:fps] = $1.to_i


### PR DESCRIPTION
Invalid UTF8 characters in FFMpeg output, caused by a 'bad' mp4 are not being removed as part of the output encoding.

My reading of the original encode line is that it should treat the input as UTF8, check every character is valid UTF8 and replace those which are not. This appears to not be the behaviour though.

Instead I'm explicitly forcing the output string to be treated as UTF8 before the conversion and check to UTF-8. This does appear to work as intended whilst being conceptually the same.
