### PR TITLE
Can we remove thumbnail creation for gifs, thus allowing mp4 -> anima…

### DIFF
--- a/lib/av/commands/base.rb
+++ b/lib/av/commands/base.rb
@@ -134,7 +134,7 @@ module Av
       def output_format format
         @output_format = format
         case format.to_s
-        when /jpg$/, /jpeg$/, /png$/, /gif$/ # Images
+        when /jpg$/, /jpeg$/, /png$/ # Images
           add_output_param 'f', 'image2'
           add_output_param 'vframes', '1'
         when /webm$/ # WebM


### PR DESCRIPTION
…ted gif transformation?

Hey there,

I was trying to use ruby-av and paperclip-av-transcoder to transform user uploaded mp4 files to gifs, and vice versa. The gif -> mp4 transformation works beautifully, and I think the only thing stopping me from being able to transform videos into animated gifs, is the default options that get added for gif files, to create a static thumbnail: "-f image2 -vframes 1".

I removed gifs from the output_format method in my project and was able to transform mp4 to gifs with the following options:

```
    styles: {
      gif: { 
        format: 'gif',
        :processors => [:transcoder],
        time: 0,
        convert_options: {
          output: {
            vf: "fps=10,scale=320:-1"
          }
        }
      }     
    }
```

Can we remove thumbnail creation for gifs?
