### PR TITLE
Inherit from StandardError rather than Exception directly

### DIFF
--- a/lib/av/exceptions.rb
+++ b/lib/av/exceptions.rb
@@ -1,8 +1,9 @@
 module Av
-  class UnableToDetect < Exception; end
-  class CommandError < Exception; end
-  class InvalidInputFile < Exception; end
-  class InvalidOutputFile < Exception; end
-  class InvalidFilterParameter < Exception; end
-  class FilterNotImplemented < Exception; end
+  class Error < StandardError; end
+  class UnableToDetect < Error; end
+  class CommandError < Error; end
+  class InvalidInputFile < Error; end
+  class InvalidOutputFile < Error; end
+  class InvalidFilterParameter < Error; end
+  class FilterNotImplemented < Error; end
 end


### PR DESCRIPTION
By default, rescue will only catch things that are `StandardError`. This is further discussed in [this](https://thoughtbot.com/blog/rescue-standarderror-not-exception) Thoughtbot article. It's much better to inherit from `StandardError`and is assumed most of the time that when you rescue `StandardError` you have your bases covered. I was caught off guard and puzzled as to how things were making there way through. It's also to have an `Av::Error` base class so you can catch all things `Av` related.